### PR TITLE
Assign InitAuthFlow() to MCaccount type

### DIFF
--- a/msa_ouath_device_flow.go
+++ b/msa_ouath_device_flow.go
@@ -227,7 +227,7 @@ func authWithToken(account *MCaccount, access_token_from_ms string) error {
 	return nil
 }
 
-func InitAuthFlow(account *MCaccount) error {
+func (account *MCaccount) InitAuthFlow() error {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
title, makes calling the function consistent to other auth funcs